### PR TITLE
Respond to user greeting

### DIFF
--- a/frontend/src/lib/message-parser.ts
+++ b/frontend/src/lib/message-parser.ts
@@ -1,0 +1,48 @@
+/**
+ * Parse think tags from LLM responses and extract them as separate thoughts
+ */
+
+export interface ParsedMessage {
+  mainContent: string;
+  thoughts: string[];
+}
+
+/**
+ * Parses content to extract think tags and returns cleaned content with separate thoughts
+ * @param content The raw content that may contain <think> tags
+ * @returns Object containing main content without think tags and array of extracted thoughts
+ */
+export function parseThinkTags(content: string): ParsedMessage {
+  const thoughts: string[] = [];
+  
+  // Regular expression to match <think> content </think> tags (including newlines)
+  const thinkTagRegex = /<think>([\s\S]*?)<\/think>/gi;
+  
+  // Extract all think tag contents
+  let match;
+  while ((match = thinkTagRegex.exec(content)) !== null) {
+    const thoughtContent = match[1].trim();
+    if (thoughtContent) {
+      thoughts.push(thoughtContent);
+    }
+  }
+  
+  // Remove all think tags from the content
+  const mainContent = content
+    .replace(thinkTagRegex, '')
+    .trim();
+  
+  return {
+    mainContent,
+    thoughts
+  };
+}
+
+/**
+ * Check if a string contains think tags
+ * @param content The content to check
+ * @returns true if content contains think tags
+ */
+export function hasThinkTags(content: string): boolean {
+  return /<think>[\s\S]*?<\/think>/i.test(content);
+}


### PR DESCRIPTION
Extract and display LLM's `<think>` tag content as distinct "thought" messages.

This change provides a clearer separation between the AI's internal reasoning and its direct response, enhancing transparency and user understanding by presenting the thought process in a dedicated UI element.

---
<a href="https://cursor.com/background-agent?bcId=bc-922c4946-8769-4add-816c-bc6a3c915e87">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-922c4946-8769-4add-816c-bc6a3c915e87">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

