### PR TITLE
Integrate new tools into agent workflow

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -145,6 +145,21 @@ class MongoDBAgent:
             await self.connect()
 
         try:
+            # Try router-planner-executor flow first for deterministic tool responses
+            try:
+                from router_planner import make_plan
+                from executor import execute
+                
+                plan = make_plan(query)
+                exec_result = await execute(plan)
+                answer = exec_result["final"]
+                
+                if answer and isinstance(answer, str) and len(answer.strip()) > 0:
+                    return answer  # Return deterministic tool result
+            except Exception as e:
+                # If planning/execution fails, continue to existing conversational flow
+                print(f"Planner/executor failed, falling back to conversational flow: {e}")
+
             # Use default conversation ID if none provided
             if not conversation_id:
                 conversation_id = f"conv_{int(time.time())}"
@@ -194,6 +209,47 @@ class MongoDBAgent:
             await self.connect()
 
         try:
+            # Try router-planner-executor flow first for deterministic tool responses
+            try:
+                from router_planner import make_plan
+                from executor import execute
+                
+                plan = make_plan(query)
+                exec_result = await execute(plan)
+                answer = exec_result["final"]
+                
+                if answer and isinstance(answer, str) and len(answer.strip()) > 0:
+                    # Stream the deterministic response in chunks for consistent UI
+                    if websocket:
+                        await websocket.send_json({
+                            "type": "llm_start",
+                            "timestamp": datetime.now().isoformat()
+                        })
+                    
+                    # Stream response in chunks
+                    chunk_size = 50
+                    for i in range(0, len(answer), chunk_size):
+                        chunk = answer[i:i+chunk_size]
+                        if websocket:
+                            await websocket.send_json({
+                                "type": "token",
+                                "content": chunk,
+                                "timestamp": datetime.now().isoformat()
+                            })
+                        yield chunk
+                        await asyncio.sleep(0.01)  # Small delay for natural streaming
+                    
+                    if websocket:
+                        await websocket.send_json({
+                            "type": "llm_end",
+                            "elapsed_time": 0.1,
+                            "timestamp": datetime.now().isoformat()
+                        })
+                    return
+            except Exception as e:
+                # If planning/execution fails, continue to existing conversational flow
+                print(f"Planner/executor failed, falling back to conversational flow: {e}")
+
             # Use default conversation ID if none provided
             if not conversation_id:
                 conversation_id = f"conv_{int(time.time())}"

--- a/executor.py
+++ b/executor.py
@@ -1,0 +1,13 @@
+# executor.py
+from __future__ import annotations
+from typing import Dict, Any
+from tool_registry import REGISTRY
+from router_planner import Plan
+
+async def execute(plan: Plan) -> Dict[str, Any]:
+    results: Dict[str, Any] = {}
+    for node in plan.nodes:
+        spec = REGISTRY[node.tool]
+        out = await spec.run(node.args)
+        results[node.id] = {"tool": node.tool, "args": node.args, "output": out}
+    return {"final": results[plan.final]["output"], "steps": results}

--- a/router_planner.py
+++ b/router_planner.py
@@ -1,0 +1,106 @@
+# router_planner.py
+from __future__ import annotations
+import re, json
+from typing import Dict, Any, List
+from pydantic import BaseModel
+from langchain_ollama import ChatOllama
+from tool_registry import REGISTRY, ToolSpec
+
+# --- Router (keyword + tags) ---
+KEYWORDS = [
+    ("status", ["search_projects_by_status","get_project_overview"]),
+    ("priority", ["get_work_item_by_priority","get_work_item_insights"]),
+    ("workload", ["get_member_workload","get_team_productivity"]),
+    ("member", ["get_member_workload","get_team_member_roles"]),
+    ("timeline", ["get_project_timeline"]),
+    ("business", ["get_business_insights"]),
+    ("count work items", ["count_work_items_by_project","get_total_work_item_count"]),
+    ("count projects", ["get_total_project_count"]),
+    ("list projects", ["list_all_projects","search_projects_by_name"]),
+    ("breakdown", ["get_work_items_breakdown_by_project"]),
+    ("project", ["search_projects_by_name","get_project_overview","get_project_work_item_details"]),
+    ("work items", ["get_project_work_item_details","get_work_item_insights"]),
+    ("cycle", ["get_cycle_overview","get_active_cycles","get_upcoming_cycles"]),
+    ("sprint", ["get_cycle_overview","get_active_cycles","get_upcoming_cycles"]),
+    ("module", ["get_module_overview","get_module_leads"]),
+    ("workflow", ["get_project_states","get_project_workflow_states"]),
+]
+
+def shortlist_tools(query: str, k: int = 6) -> List[ToolSpec]:
+    q = query.lower()
+    scores: Dict[str,int] = {}
+    # keyword boosts
+    for kw, tools in KEYWORDS:
+        if kw in q:
+            for t in tools:
+                scores[t] = scores.get(t,0) + 5
+    # tag proximity
+    for name, spec in REGISTRY.items():
+        tag_hits = sum(1 for tag in spec.tags if tag in q)
+        scores[name] = scores.get(name,0) + tag_hits
+        # generic project/workitems clue
+        if "project" in q and "project" in spec.tags: scores[name]+=1
+        if "work" in q and "workitems" in spec.tags: scores[name]+=1
+    ranked = sorted(REGISTRY.values(), key=lambda s: scores.get(s.name,0), reverse=True)
+    return ranked[:k]
+
+# --- Plan schema ---
+class PlanNode(BaseModel):
+    id: str
+    tool: str
+    args: Dict[str, Any] = {}
+class Plan(BaseModel):
+    nodes: List[PlanNode]
+    final: str  # id of final node
+
+# Simple arg extraction heuristics
+STATUS_VALUES = ["STARTED","COMPLETED","ONHOLD","CANCELLED","PLANNED","PAUSED","ACTIVE","UPCOMING"]
+PRIO_VALUES = ["P0","P1","P2","P3","HIGH","MEDIUM","LOW"]
+
+def _extract_status(q: str) -> str|None:
+    for s in STATUS_VALUES:
+        if s.lower() in q.lower(): return s
+    return None
+
+def _extract_priority(q: str) -> str|None:
+    for p in PRIO_VALUES:
+        if p.lower() in q.lower(): return p
+    return None
+
+def _extract_email(q: str) -> str|None:
+    m = re.search(r'[\w\.-]+@[\w\.-]+\.\w+', q)
+    return m.group(0) if m else None
+
+def _extract_project_name(q: str) -> str|None:
+    # try quoted text first
+    m = re.search(r'"([^"]+)"|\'([^\']+)\'', q)
+    if m: return (m.group(1) or m.group(2))
+    # fallback: title-ish phrase after 'for' or 'of'
+    m = re.search(r'(?:for|of|project)\s+([A-Z][\w \-]{2,40})', q, re.IGNORECASE)
+    if m: return m.group(1).strip()
+    # more fallback: any capitalized phrase
+    m = re.search(r'([A-Z][\w \-]{2,40})', q)
+    return m.group(1).strip() if m else None
+
+def make_plan(query: str, model_name: str = "llama3.1") -> Plan:
+    shortlist = shortlist_tools(query)
+    ql = query.lower()
+
+    # choose primary
+    primary = shortlist[0].name if shortlist else "get_project_overview"
+    args: Dict[str,Any] = {}
+
+    if primary == "search_projects_by_status":
+        args["status"] = _extract_status(query) or "STARTED"
+    elif primary == "get_work_item_by_priority":
+        args["priority"] = _extract_priority(query) or "P1"
+    elif primary in ("get_member_workload",):
+        email = _extract_email(query)
+        if email: args["email"] = email
+    elif primary in ("search_projects_by_name","count_work_items_by_project","get_project_work_item_details","get_project_workflow_states"):
+        pname = _extract_project_name(query) or ( " ".join(w for w in query.split() if w.isalpha())[:32] or "TEST" )
+        key = "name" if primary=="search_projects_by_name" else "project_name"
+        args[key] = pname
+
+    nodes = [PlanNode(id="n1", tool=primary, args=args)]
+    return Plan(nodes=nodes, final="n1")

--- a/tool_registry.py
+++ b/tool_registry.py
@@ -1,0 +1,127 @@
+# tool_registry.py
+from __future__ import annotations
+from pydantic import BaseModel, Field
+from typing import Any, Callable, Awaitable, Dict, List, Optional, Literal
+import asyncio
+import inspect
+import tools as user_tools  # your /mnt/data/tools.py
+
+class ToolSpec(BaseModel):
+    name: str
+    description: str
+    input_schema: Dict[str, Any] = Field(default_factory=dict)
+    output_schema: Optional[Dict[str, Any]] = None
+    tags: List[str] = Field(default_factory=list)
+    freshness: Literal["static","daily","hourly","realtime"] = "daily"
+    est_latency_ms: int = 300
+    reliability: float = 0.98
+    run: Callable[[Dict[str, Any]], Awaitable[Any]]
+
+def _wrap_async(func: Callable[..., Any]) -> Callable[[Dict[str, Any]], Awaitable[Any]]:
+    async def _runner(args: Dict[str, Any]) -> Any:
+        sig = inspect.signature(func)
+        bound = sig.bind_partial(**(args or {}))
+        bound.apply_defaults()
+        if inspect.iscoroutinefunction(func):
+            return await func(*bound.args, **bound.kwargs)
+        return func(*bound.args, **bound.kwargs)
+    return _runner
+
+def _spec(name: str,
+          description: str,
+          fn: Callable[..., Any],
+          input_schema: Dict[str, Any],
+          tags: List[str],
+          est_latency_ms: int = 300) -> ToolSpec:
+    return ToolSpec(
+        name=name,
+        description=description,
+        input_schema=input_schema,
+        output_schema={"type": "string"},
+        tags=tags,
+        est_latency_ms=est_latency_ms,
+        run=_wrap_async(getattr(user_tools, name))
+    )
+
+REGISTRY: Dict[str, ToolSpec] = {}
+
+def register_all() -> Dict[str, ToolSpec]:
+    # No-arg tools
+    for name, desc, tags in [
+        ("get_project_overview",        "Portfolio snapshot of projects by status plus quick stats.", ["project","portfolio","status"]),
+        ("get_work_item_insights",      "Aggregated insights about work items across projects.",      ["workitems","insight"]),
+        ("get_team_productivity",       "Team throughput/velocity overview.",                         ["team","productivity"]),
+        ("get_project_timeline",        "Recent project activity/timeline entries.",                  ["project","timeline"]),
+        ("get_business_insights",       "Business unit performance across projects.",                 ["business","portfolio"]),
+        ("get_total_project_count",     "Count of all projects.",                                     ["project","count"]),
+        ("get_total_work_item_count",   "Count of all work items.",                                   ["workitems","count"]),
+        ("list_all_projects",           "List every project with basic fields.",                      ["project","list"]),
+        ("get_work_items_breakdown_by_project", "Per-project work items breakdown.",                  ["workitems","project","breakdown"]),
+        ("get_cycle_overview",          "Cycle status distribution with counts and cycle details.",   ["cycle","sprint","overview"]),
+        ("get_active_cycles",           "All currently active cycles with their details.",            ["cycle","sprint","active"]),
+        ("get_module_overview",         "Module status and lead distribution across projects.",       ["module","overview"]),
+        ("get_project_states",          "All project states and their sub-states for workflow.",      ["project","workflow","states"]),
+        ("get_team_member_roles",       "Team member role distribution across projects.",             ["team","member","roles"]),
+        ("get_upcoming_cycles",         "Upcoming cycles sorted by start date.",                      ["cycle","sprint","upcoming"]),
+        ("get_module_leads",            "Module lead distribution and workload.",                     ["module","lead","workload"]),
+    ]:
+        REGISTRY[name] = _spec(
+            name, desc, getattr(user_tools, name),
+            input_schema={"type":"object","properties":{},"additionalProperties":False},
+            tags=tags
+        )
+
+    # Single-arg tools
+    REGISTRY["search_projects_by_status"] = _spec(
+        "search_projects_by_status",
+        "Find projects filtered by status (e.g., STARTED, COMPLETED).",
+        user_tools.search_projects_by_status,
+        {"type":"object","properties":{"status":{"type":"string"}}, "required":["status"], "additionalProperties":False},
+        ["project","status","search"]
+    )
+    REGISTRY["get_work_item_by_priority"] = _spec(
+        "get_work_item_by_priority",
+        "List work items by priority (e.g., P0, P1, High, Medium, Low).",
+        user_tools.get_work_item_by_priority,
+        {"type":"object","properties":{"priority":{"type":"string"}}, "required":["priority"], "additionalProperties":False},
+        ["workitems","priority","search"]
+    )
+    REGISTRY["get_member_workload"] = _spec(
+        "get_member_workload",
+        "Workload for a specific member (email) or all members if email omitted.",
+        user_tools.get_member_workload,
+        {"type":"object","properties":{"email":{"type":"string"}}, "additionalProperties":False},
+        ["member","workload"]
+    )
+    REGISTRY["search_projects_by_name"] = _spec(
+        "search_projects_by_name",
+        "Search projects by name (partial/keyword).",
+        user_tools.search_projects_by_name,
+        {"type":"object","properties":{"name":{"type":"string"}}, "required":["name"], "additionalProperties":False},
+        ["project","search","name"]
+    )
+    REGISTRY["count_work_items_by_project"] = _spec(
+        "count_work_items_by_project",
+        "Count work items belonging to a specific project.",
+        user_tools.count_work_items_by_project,
+        {"type":"object","properties":{"project_name":{"type":"string"}}, "required":["project_name"], "additionalProperties":False},
+        ["workitems","project","count"]
+    )
+    REGISTRY["get_project_work_item_details"] = _spec(
+        "get_project_work_item_details",
+        "List detailed work items for a given project.",
+        user_tools.get_project_work_item_details,
+        {"type":"object","properties":{"project_name":{"type":"string"}}, "required":["project_name"], "additionalProperties":False},
+        ["workitems","project","details"]
+    )
+    REGISTRY["get_project_workflow_states"] = _spec(
+        "get_project_workflow_states",
+        "Returns workflow states for a specific project.",
+        user_tools.get_project_workflow_states,
+        {"type":"object","properties":{"project_name":{"type":"string"}}, "required":["project_name"], "additionalProperties":False},
+        ["project","workflow","states"]
+    )
+    return REGISTRY
+
+# one-time init
+register_all()


### PR DESCRIPTION
Implement a router-planner-executor flow to enable tool-first answering for 23 tools.

This provides faster, more deterministic responses for common queries by directly executing tools, with a graceful fallback to the existing LLM conversational flow.

---
<a href="https://cursor.com/background-agent?bcId=bc-2cbe7d5c-3c0d-4a50-850e-eb74fda12f42">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2cbe7d5c-3c0d-4a50-850e-eb74fda12f42">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

