### PR TITLE
Refactor work item state and priority handling

### DIFF
--- a/registry.py
+++ b/registry.py
@@ -138,7 +138,7 @@ Collection = str  # Simplified for tool usage
 ALLOWED_FIELDS: Dict[str, Set[str]] = {
     "workItem": {
         "_id", "displayBugNo", "title", "description",
-        "status", "priority",
+        "priority",
         "stateMaster.name",
         "project._id", "project.name",
         "createdBy._id", "createdBy.name",


### PR DESCRIPTION
Migrate work item progress tracking from 'status' to 'state' and ensure 'state'/'priority' filters are applied only when explicitly requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-2fffbb3d-acc3-4c6e-a7dc-c16b4bed1cfb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2fffbb3d-acc3-4c6e-a7dc-c16b4bed1cfb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

