### PR TITLE
Fix unreachable code error

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -656,29 +656,29 @@ class MongoDBAgent:
                                 llm_span.add_event("llm_prompt", {"message_count": len(messages)})
                             except Exception:
                                 pass
-                # Lightweight routing hint to bias correct tool choice
-                routing_instructions = SystemMessage(content=(
-                    "ROUTING REMINDER: Choose one tool per step using the Decision Guide. "
-                    "If the user asks for DB facts, prefer 'mongo_query'. If asking about content, prefer RAG tools."
-                ))
-                # In non-streaming mode, also support a synthesis pass after tools
-                invoke_messages = messages + [routing_instructions]
-                if need_finalization:
-                    finalization_instructions = SystemMessage(content=(
-                        "FINALIZATION: Write a concise answer in your own words based on the tool outputs above. "
-                        "Do not paste tool outputs verbatim. Focus on the specific fields requested; if multiple items, present a compact list."
-                    ))
-                    invoke_messages = messages + [routing_instructions, finalization_instructions]
-                    need_finalization = False
+                        # Lightweight routing hint to bias correct tool choice
+                        routing_instructions = SystemMessage(content=(
+                            "ROUTING REMINDER: Choose one tool per step using the Decision Guide. "
+                            "If the user asks for DB facts, prefer 'mongo_query'. If asking about content, prefer RAG tools."
+                        ))
+                        # In non-streaming mode, also support a synthesis pass after tools
+                        invoke_messages = messages + [routing_instructions]
+                        if need_finalization:
+                            finalization_instructions = SystemMessage(content=(
+                                "FINALIZATION: Write a concise answer in your own words based on the tool outputs above. "
+                                "Do not paste tool outputs verbatim. Focus on the specific fields requested; if multiple items, present a compact list."
+                            ))
+                            invoke_messages = messages + [routing_instructions, finalization_instructions]
+                            need_finalization = False
 
-                response = await llm_with_tools.ainvoke(invoke_messages)
-                if llm_span and getattr(response, "content", None):
-                        try:
-                            preview = str(response.content)[:500]
-                            llm_span.set_attribute(getattr(OI, 'OUTPUT_VALUE', 'output.value'), preview)
-                            llm_span.add_event("llm_response", {"preview_len": len(preview)})
-                        except Exception:
-                            pass
+                        response = await llm_with_tools.ainvoke(invoke_messages)
+                        if llm_span and getattr(response, "content", None):
+                            try:
+                                preview = str(response.content)[:500]
+                                llm_span.set_attribute(getattr(OI, 'OUTPUT_VALUE', 'output.value'), preview)
+                                llm_span.add_event("llm_response", {"preview_len": len(preview)})
+                            except Exception:
+                                pass
                 last_response = response
 
                 # Persist assistant message


### PR DESCRIPTION
Move routing and invocation logic into the LLM span context to resolve "Code is unreachable" warnings.

The previous placement of routing and invocation code outside the `llm_span` context could lead static analysis to incorrectly flag subsequent code as unreachable, especially after early returns within the span. Moving these operations inside the span ensures consistent control flow and eliminates these warnings.

---
<a href="https://cursor.com/background-agent?bcId=bc-acfc2023-133a-4bc4-9de2-8b34678664e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-acfc2023-133a-4bc4-9de2-8b34678664e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

