### PR TITLE
Fix entity identification and project naming in collections

### DIFF
--- a/tools.py
+++ b/tools.py
@@ -320,7 +320,12 @@ def _transform_by_collection(doc: Dict[str, Any], collection: Optional[str]) -> 
         set_name("staff", "staffName")
 
     elif collection == "page":
-        set_name("project", "projectName")
+        # Some lookups/project embeddings use alias 'projectDoc'
+        project_obj = doc.get("project") or doc.get("projectDoc")
+        if isinstance(project_obj, dict):
+            name = project_obj.get("name") or project_obj.get("title")
+            if name:
+                out["projectName"] = name
         set_name("createdBy", "createdByName")
         set_name("business", "businessName")
         # Linked arrays could contain ids only; surface counts


### PR DESCRIPTION
Refine primary entity detection and ensure project names are available for non-workItem collections to improve cross-entity query accuracy.

The planner frequently misidentified the primary entity, especially when queries involved both item-level and project-level filters. Furthermore, most collections only stored `projectId` without `projectName`, making cross-entity questions requiring project names difficult without complex query chaining. This PR addresses these by improving LLM prompting, adding heuristic corrections, and automatically joining project details for relevant collections.

---
<a href="https://cursor.com/background-agent?bcId=bc-48f1e32b-fcfa-40b8-a6eb-76f41e39f6a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-48f1e32b-fcfa-40b8-a6eb-76f41e39f6a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

