### PR TITLE
Normalize project data for safe lookups and projections

### DIFF
--- a/mongo/registry.py
+++ b/mongo/registry.py
@@ -195,19 +195,25 @@ ALLOWED_FIELDS: Dict[str, Set[str]] = {
         "project._id",
         "isDefault", "isFavourite",
         "createdTimeStamp", "updatedTimeStamp",
-        "business._id"
+        "business._id",
+        # normalized scalar fields from planner
+        "projectName", "projectBusinessName", "projectId"
     },
     "module": {
         "_id", "title", "name", "description", "isFavourite",
         "project._id", "business._id",
         "createdTimeStamp", "assignee",
         # optional lead object commonly present in modules
-        "lead.name"
+        "lead.name",
+        # normalized scalar fields from planner
+        "projectName", "projectBusinessName", "projectId"
     },
     "members": {
         "_id", "name", "email", "role", "joiningDate",
         "type", "project._id", "project.name",
-        "memberId", "staff._id", "staff.name"
+        "memberId", "staff._id", "staff.name",
+        # normalized scalar fields from planner
+        "projectName", "projectBusinessName", "projectId"
     },
     "page": {
         "_id", "title", "content", "visibility",
@@ -216,7 +222,9 @@ ALLOWED_FIELDS: Dict[str, Set[str]] = {
         "linkedCycle", "linkedModule",
         "locked", "isFavourite",
         "createdAt", "updatedAt",
-        "business._id", "business.name"
+        "business._id", "business.name",
+        # normalized scalar fields from planner
+        "projectName", "projectBusinessName", "projectId"
     },
     "projectState": {
         "_id", "projectId", "name", "icon",


### PR DESCRIPTION
Refactor project lookups, normalize project fields to scalars, and update filters/projections to use these new fields.

This prevents `$lookup` from clobbering embedded `project` fields, ensuring stable scalar `projectName`, `projectId`, and `projectBusinessName` for consistent filtering and display.

---
<a href="https://cursor.com/background-agent?bcId=bc-bc6916bc-76ff-40f0-9240-be6bc76b163a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bc6916bc-76ff-40f0-9240-be6bc76b163a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

