### PR TITLE
Handle complex queries with tool chaining

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -178,6 +178,17 @@ def _select_tools_for_query(user_query: str):
         if has_any(workitem_terms) and has_any(canonical_field_terms):
             allowed_names.append("rag_to_mongo_workitems")
 
+    # Heuristic: enable composite orchestrator when the query likely needs multi-part handling
+    multi_markers = [
+        "compare", " versus ", " vs ", "side by side", "both ", " and also ", " together ", ";"
+    ]
+    needs_composite = (
+        has_any(multi_markers)
+        or (allow_rag and has_any(canonical_field_terms))
+    )
+    if needs_composite:
+        allowed_names.append("composite_query")
+
     # Map to actual tool objects, keep only those present
     selected_tools = [tool for name, tool in _TOOLS_BY_NAME.items() if name in allowed_names]
     # Fallback safety: if mapping failed for any reason, expose mongo_query only


### PR DESCRIPTION
Add a `composite_query` tool and update agent routing to enable tool chaining and query breakdown for multi-part queries.

---
<a href="https://cursor.com/background-agent?bcId=bc-b8a7c5a3-03e8-4585-b53d-966c4f4e1849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b8a7c5a3-03e8-4585-b53d-966c4f4e1849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

