### PR TITLE
Get overdue tasks by project and priority

### DIFF
--- a/mongo/registry.py
+++ b/mongo/registry.py
@@ -175,7 +175,7 @@ ALLOWED_FIELDS: Dict[str, Set[str]] = {
         "cycle._id", "cycle.name",
         "modules._id", "modules.name",
         "createdBy._id", "createdBy.name",
-        "createdTimeStamp", "updatedTimeStamp",
+        "createdTimeStamp", "updatedTimeStamp", "dueDate",
         "assignee", "assignee._id", "assignee.name", "label"
     },
     "project": {


### PR DESCRIPTION
Generalize planner to infer grouping from phrasing and correctly interpret 'overdue' for work items.

The previous planner incorrectly processed queries like "overdue tasks by project and priority" by failing to infer grouping from "by X" phrases, lacking specific "overdue" logic for `workItem` (e.g., `dueDate < now` and not-done states), and not allowing `dueDate` as a filter. This resulted in a simple filtered list rather than the requested grouped breakdown, a common issue across many queries.

---
<a href="https://cursor.com/background-agent?bcId=bc-bfe51afc-86a2-4ce7-9a84-0e63a990b389"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bfe51afc-86a2-4ce7-9a84-0e63a990b389"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

