### PR TITLE
Categorize information by query parameters

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -216,7 +216,7 @@ def _select_tools_for_query(user_query: str):
     allowed_names = ["mongo_query"]
     if allow_rag:
         # Allow content-oriented RAG tools
-        allowed_names.extend(["rag_content_search", "rag_answer_question"])
+        allowed_names.extend(["rag_content_search", "rag_answer_question", "rag_grouped_search"])
         # Only allow rag_to_mongo_workitems when user mentions work items AND canonical fields
         if has_any(workitem_terms) and has_any(canonical_field_terms):
             allowed_names.append("rag_to_mongo_workitems")


### PR DESCRIPTION
Add a RAG grouped search tool and metadata indexing to support content breakdown queries by type, project, or date.

This PR extends RAG capabilities to handle "breakdown" or "group by" queries on semantically matched content (e.g., search results for a query grouped by content type or project). It introduces a new `rag_grouped_search` tool and ensures relevant metadata (`updated_at`, `project_name`) is indexed in Qdrant, allowing for generalized content-oriented aggregations.

---
<a href="https://cursor.com/background-agent?bcId=bc-a53eabdc-0daa-4575-9295-68c1dbf8fc30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a53eabdc-0daa-4575-9295-68c1dbf8fc30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

