### PR TITLE
Investigate zero indexed vectors in qdrant

### DIFF
--- a/qdrant/dbconnection.py
+++ b/qdrant/dbconnection.py
@@ -1,7 +1,7 @@
 import os
 from pymongo import MongoClient
 from qdrant_client import QdrantClient
-from qdrant_client.http.models import Distance, VectorParams
+from qdrant_client.http.models import Distance, VectorParams, OptimizersConfigDiff
 from dotenv import load_dotenv
 # from tools import rag_content_search
 
@@ -52,6 +52,16 @@ try:
                 distance=Distance.COSINE
             )
         )
+    
+    # Force immediate indexing on this collection
+    try:
+        qdrant_client.update_collection(
+            collection_name=QDRANT_COLLECTION,
+            optimizer_config=OptimizersConfigDiff(indexing_threshold=1)
+        )
+        print("✅ Qdrant optimizer indexing_threshold set to 1")
+    except Exception as e:
+        print(f"⚠️ Failed to set optimizer config: {e}")
     # if QDRANT_COLLECTION_WORKITEM not in [col.name for col in qdrant_client.get_collections().collections]:
     #     qdrant_client.recreate_collection(
     #         collection_name=QDRANT_COLLECTION_WORKITEM,

--- a/qdrant/insertdocs.py
+++ b/qdrant/insertdocs.py
@@ -5,7 +5,7 @@ import uuid
 from itertools import islice
 from bson.binary import Binary
 from bson.objectid import ObjectId
-from qdrant_client.http.models import PointStruct, PayloadSchemaType, Distance, VectorParams
+from qdrant_client.http.models import PointStruct, PayloadSchemaType, Distance, VectorParams, OptimizersConfigDiff
 from sentence_transformers import SentenceTransformer
 from collections import defaultdict
 
@@ -133,6 +133,16 @@ def ensure_collection_with_hybrid(collection_name: str, vector_size: int = 768):
                 vectors_config=VectorParams(size=vector_size, distance=Distance.COSINE),
             )
             print(f"✅ Collection '{collection_name}' created")
+        
+        # Force immediate HNSW indexing by lowering the threshold
+        try:
+            qdrant_client.update_collection(
+                collection_name=collection_name,
+                optimizer_config=OptimizersConfigDiff(indexing_threshold=1)
+            )
+            print("✅ Set indexing_threshold=1 for immediate indexing")
+        except Exception as e:
+            print(f"⚠️ Failed to update optimizer config: {e}")
 
         # Ensure keyword and text payload indexes exist (idempotent)
         try:


### PR DESCRIPTION
Force immediate Qdrant HNSW indexing by setting `indexing_threshold=1` to ensure vectors are indexed promptly after insertion.

The `indexed_vectors_count` was reported as 0 even when points were present, indicating that Qdrant's background optimizer was not triggering indexing. This change configures the collection to start HNSW indexing immediately after any points are inserted, resolving the delay.

---
<a href="https://cursor.com/background-agent?bcId=bc-3eb8ef4b-b092-46da-8867-2a5bb66f8455"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3eb8ef4b-b092-46da-8867-2a5bb66f8455"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

