### PR TITLE
Split prompt finalization by scenario

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -450,6 +450,174 @@ Do NOT paste tool outputs verbatim. Do NOT include emojis or banners.""",
 }
 
 
+# Sectioned finalization prompts for cleaner, focused synthesis per scenario
+FINALIZATION_PROMPT_SECTIONS = {
+    "count": {
+        "overview": "FINALIZATION (Count/Summary Response):",
+        "structure": (
+            "Based on the tool outputs above, provide a CONCISE numeric answer.\n\n"
+            "Structure your response as:\n"
+            "1. Direct answer with the count/total (e.g., \"There are X items...\")\n"
+            "2. One-sentence context if relevant (e.g., breakdown by key dimension)\n"
+            "3. Offer to provide more details if helpful\n"
+        ),
+        "guidelines": (
+            "Keep it SHORT - 2-3 sentences maximum. Focus on the NUMBER.\n"
+            "Do NOT include \"SCENARIO:\" tag in your final response.\n"
+            "Do NOT paste tool outputs verbatim. Do NOT include emojis or banners."
+        ),
+    },
+    "breakdown": {
+        "overview": "FINALIZATION (Breakdown/Distribution Response):",
+        "structure": (
+            "Based on the tool outputs above, present the grouped data in a CLEAR, STRUCTURED way.\n\n"
+            "Structure your response as:\n"
+            "1. Brief summary of total items and what they're grouped by\n"
+            "2. Top 5-7 categories with their counts in a clean format:\n"
+            "   • Category Name: X items (with key details if relevant)\n"
+            "3. Mention remaining categories if truncated\n"
+            "4. One insight about the distribution (e.g., \"Most items are...\")\n"
+        ),
+        "guidelines": (
+            "Keep it ORGANIZED and SCANNABLE. Use bullet points effectively.\n"
+            "Do NOT include \"SCENARIO:\" tag in your final response.\n"
+            "Do NOT paste raw tool outputs. Do NOT include emojis or banners."
+        ),
+    },
+    "list": {
+        "overview": "FINALIZATION (List Response):",
+        "structure": (
+            "Based on the tool outputs above, present the items as a CLEAN, FORMATTED list.\n\n"
+            "Structure your response as:\n"
+            "1. Brief intro stating how many items found\n"
+            "2. List items (max 10-15) with essential fields:\n"
+            "   • Item identifier: Key details (state, priority, assignee, date as relevant)\n"
+            "3. Mention if list is truncated (\"...and X more items\")\n"
+            "4. Offer to show more details or filter if helpful\n"
+        ),
+        "guidelines": (
+            "Keep it CONCISE per item - one line with 3-4 key fields.\n"
+            "Do NOT include \"SCENARIO:\" tag in your final response.\n"
+            "Do NOT paste tool outputs verbatim. Do NOT include emojis or banners."
+        ),
+    },
+    "detail": {
+        "overview": "FINALIZATION (Detail Response):",
+        "structure": (
+            "Based on the tool outputs above, provide COMPREHENSIVE information about the requested item(s).\n\n"
+            "Structure your response as:\n"
+            "1. Item name/title and type\n"
+            "2. Key fields organized by category:\n"
+            "   - Status & Priority\n"
+            "   - Assignment & Ownership\n"
+            "   - Dates & Timeline\n"
+            "   - Related entities (project, cycle, module)\n"
+            "   - Description/Content summary (if available)\n"
+            "3. Any notable relationships or dependencies\n"
+        ),
+        "guidelines": (
+            "Keep it INFORMATIVE but ORGANIZED. Use clear sections.\n"
+            "Do NOT include \"SCENARIO:\" tag in your final response.\n"
+            "Do NOT paste tool outputs verbatim. Do NOT include emojis or banners."
+        ),
+    },
+    "comparison": {
+        "overview": "FINALIZATION (Comparison Response):",
+        "structure": (
+            "Based on the tool outputs above, provide a CLEAR COMPARISON between entities.\n\n"
+            "Structure your response as:\n"
+            "1. Brief intro of what's being compared\n"
+            "2. Side-by-side comparison table or structured list:\n"
+            "   - Entity A: [key metrics/fields]\n"
+            "   - Entity B: [key metrics/fields]\n"
+            "3. 2-3 key differences or similarities\n"
+            "4. Brief conclusion or recommendation if appropriate\n"
+        ),
+        "guidelines": (
+            "Keep it BALANCED and FACTUAL. Highlight differences clearly.\n"
+            "Do NOT include \"SCENARIO:\" tag in your final response.\n"
+            "Do NOT paste tool outputs verbatim. Do NOT include emojis or banners."
+        ),
+    },
+    "analysis": {
+        "overview": "FINALIZATION (Analysis Response):",
+        "structure": (
+            "Based on the tool outputs above, provide ANALYTICAL INSIGHTS.\n\n"
+            "Structure your response as:\n"
+            "1. Summary of the data/context analyzed\n"
+            "2. Key findings (2-4 bullet points):\n"
+            "   • Pattern/trend observed\n"
+            "   • Notable statistics or distributions\n"
+            "   • Potential issues or opportunities\n"
+            "3. Brief interpretation or recommendation\n"
+            "4. Suggest follow-up questions if helpful\n"
+        ),
+        "guidelines": (
+            "Keep it INSIGHTFUL and ACTION-ORIENTED. Focus on meaning, not just data.\n"
+            "Do NOT include \"SCENARIO:\" tag in your final response.\n"
+            "Do NOT paste tool outputs verbatim. Do NOT include emojis or banners."
+        ),
+    },
+    "search": {
+        "overview": "FINALIZATION (Search Response):",
+        "structure": (
+            "Based on the tool outputs above, present the MOST RELEVANT search results.\n\n"
+            "Structure your response as:\n"
+            "1. Brief summary of what was found\n"
+            "2. Top 5-8 results with:\n"
+            "   • Title/name (relevance score if helpful)\n"
+            "   • Brief preview/context showing why it matched\n"
+            "   • Key metadata (project, date, type, etc.)\n"
+            "3. Mention total results if more are available\n"
+            "4. Suggest ways to refine search if needed\n"
+        ),
+        "guidelines": (
+            "Keep it RELEVANT and CONTEXTUAL. Show WHY items matched.\n"
+            "Do NOT include \"SCENARIO:\" tag in your final response.\n"
+            "Do NOT paste tool outputs verbatim. Do NOT include emojis or banners."
+        ),
+    },
+    "export": {
+        "overview": "FINALIZATION (Export Response):",
+        "structure": (
+            "Based on the tool outputs above, confirm the export operation.\n\n"
+            "Structure your response as:\n"
+            "1. Confirmation of what was exported\n"
+            "2. File location and format\n"
+            "3. Number of records/items exported\n"
+            "4. Brief note on how to access or use the exported file\n"
+        ),
+        "guidelines": (
+            "Keep it CLEAR and ACTIONABLE. Provide file path.\n"
+            "Do NOT include \"SCENARIO:\" tag in your final response.\n"
+            "Do NOT paste tool outputs verbatim. Do NOT include emojis or banners."
+        ),
+    },
+}
+
+
+def build_finalization_prompt(scenario: str) -> str:
+    """Compose a focused finalization prompt from sections for the given scenario."""
+    scenario_key = (scenario or "").lower()
+    if scenario_key not in FINALIZATION_PROMPT_SECTIONS:
+        scenario_key = "search"
+    sections = FINALIZATION_PROMPT_SECTIONS[scenario_key]
+    return f"{sections['overview']}\n\n{sections['structure']}\n{sections['guidelines']}"
+
+
+def extract_scenario_tag(text: str) -> Optional[str]:
+    """Extract scenario tag from text like 'SCENARIO: search' and return normalized key."""
+    try:
+        import re
+        match = re.search(r"SCENARIO:\s*(\w+)", str(text or ""), re.IGNORECASE)
+        if not match:
+            return None
+        candidate = match.group(1).lower()
+        return candidate if candidate in FINALIZATION_PROMPT_SECTIONS else None
+    except Exception:
+        return None
+
+
 def _select_tools_for_query(user_query: str):
     """Return a subset of tools to expose to the LLM for this query.
 
@@ -1119,18 +1287,10 @@ class MongoDBAgent:
                 # In non-streaming mode, also support a synthesis pass after tools
                 invoke_messages = messages + [routing_instructions]
                 if need_finalization:
-                    # Extract scenario from LLM's previous response (if present)
-                    scenario = "search"  # default
-                    if last_response and hasattr(last_response, "content"):
-                        import re
-                        scenario_match = re.search(r"SCENARIO:\s*(\w+)", str(last_response.content), re.IGNORECASE)
-                        if scenario_match:
-                            detected = scenario_match.group(1).lower()
-                            if detected in FINALIZATION_PROMPTS:
-                                scenario = detected
-                    
+                    # Extract scenario from the latest assistant response
+                    scenario = extract_scenario_tag(getattr(last_response, "content", "")) or "search"
                     print(f"🎯 Response scenario: {scenario.upper()}")
-                    finalization_prompt = FINALIZATION_PROMPTS.get(scenario, FINALIZATION_PROMPTS["search"])
+                    finalization_prompt = build_finalization_prompt(scenario)
                     finalization_instructions = SystemMessage(content=finalization_prompt)
                     invoke_messages = messages + [routing_instructions, finalization_instructions]
                     need_finalization = False
@@ -1148,8 +1308,16 @@ class MongoDBAgent:
                 # Persist assistant message
                 conversation_memory.add_message(conversation_id, response)
 
-                # If no tools requested, we are done
+                # If no tools requested, check for scenario tag and perform one-shot finalization
                 if not getattr(response, "tool_calls", None):
+                    scenario = extract_scenario_tag(getattr(response, "content", ""))
+                    if scenario:
+                        finalization_prompt = build_finalization_prompt(scenario)
+                        finalization_instructions = SystemMessage(content=finalization_prompt)
+                        # Perform a final synthesis pass with focused prompt
+                        synthesis = await llm_with_tools.ainvoke(messages + [routing_instructions, finalization_instructions])
+                        conversation_memory.add_message(conversation_id, synthesis)
+                        return synthesis.content
                     return response.content
 
                 # Execute requested tools
@@ -1317,18 +1485,10 @@ class MongoDBAgent:
                         ))
                         invoke_messages = messages + [routing_instructions]
                         if need_finalization:
-                            # Extract scenario from LLM's previous response (if present)
-                            scenario = "search"  # default
-                            if last_response and hasattr(last_response, "content"):
-                                import re
-                                scenario_match = re.search(r"SCENARIO:\s*(\w+)", str(last_response.content), re.IGNORECASE)
-                                if scenario_match:
-                                    detected = scenario_match.group(1).lower()
-                                    if detected in FINALIZATION_PROMPTS:
-                                        scenario = detected
-                            
+                            # Extract scenario from the latest assistant response
+                            scenario = extract_scenario_tag(getattr(last_response, "content", "")) or "search"
                             print(f"🎯 Response scenario: {scenario.upper()}")
-                            finalization_prompt = FINALIZATION_PROMPTS.get(scenario, FINALIZATION_PROMPTS["search"])
+                            finalization_prompt = build_finalization_prompt(scenario)
                             finalization_instructions = SystemMessage(content=finalization_prompt)
                             invoke_messages = messages + [routing_instructions, finalization_instructions]
                             need_finalization = False
@@ -1349,6 +1509,17 @@ class MongoDBAgent:
                     conversation_memory.add_message(conversation_id, response)
 
                     if not getattr(response, "tool_calls", None):
+                        scenario = extract_scenario_tag(getattr(response, "content", ""))
+                        if scenario:
+                            finalization_prompt = build_finalization_prompt(scenario)
+                            finalization_instructions = SystemMessage(content=finalization_prompt)
+                            synthesis = await llm_with_tools.ainvoke(
+                                messages + [routing_instructions, finalization_instructions],
+                                config={"callbacks": [callback_handler]},
+                            )
+                            conversation_memory.add_message(conversation_id, synthesis)
+                            yield synthesis.content
+                            return
                         yield response.content
                         return
 


### PR DESCRIPTION
Split finalization prompts into scenario-specific sections and ensure a focused finalization pass is triggered for all scenario-tagged responses, resolving unreachable code and improving response generation.

---
<a href="https://cursor.com/background-agent?bcId=bc-46cc72a3-532b-4afb-9efe-4e0660e2f1e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-46cc72a3-532b-4afb-9efe-4e0660e2f1e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

