### PR TITLE
Improve excel task data structure for agent queries

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -108,6 +108,10 @@ DEFAULT_SYSTEM_PROMPT = (
     "- If the question references states, assignees, counts, filters, dates, or IDs → mongo_query.\n"
     "- If the question references 'content', 'notes', 'docs', 'pages', 'descriptions', or needs semantic search → rag_search.\n"
     "- If the user searches by content BUT needs complete MongoDB fields (state, assignee, dates, etc.) → rag_mongo.\n\n"
+    "EXPORT PLAYBOOK:\n"
+    "- For export flows (Excel/Markdown), FIRST call mongo_query with output_format='rows' to get clean JSON rows.\n"
+    "- Then call export_excel/export_doc with those rows and explicit fields (dot paths allowed, e.g., 'state.name').\n"
+    "- Prefer date windows with explicit boundaries (e.g., 'updatedAt between <start> and <end>').\n\n"
     "Respond with tool calls first, then synthesize a concise answer grounded ONLY in tool outputs."
 )
 


### PR DESCRIPTION
Add `output_format='rows'` to `mongo_query` and dot-path field support to `_coerce_to_rows` to enable direct data export to Excel.

This allows the agent to generate structured Excel sheets from complex queries by passing raw JSON rows from `mongo_query` directly to export tools, supporting nested fields like `state.name`.

---
<a href="https://cursor.com/background-agent?bcId=bc-264ba20f-4bdc-43fb-9ed3-d6fbd98e917c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-264ba20f-4bdc-43fb-9ed3-d6fbd98e917c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

