### PR TITLE
Fix incomplete content retrieval

### DIFF
--- a/qdrant/qdrant_initializer.py
+++ b/qdrant/qdrant_initializer.py
@@ -99,12 +99,15 @@ class RAGTool:
             # print(f"total results",search_results)
             for result in search_results:
                 payload = result.payload or {}
+                # Prefer 'content'; fallback to 'full_text' or 'title' so content is never empty
+                content_text = payload.get("content") or payload.get("full_text") or payload.get("title", "")
+
                 # Create a result dict with all payload fields
                 result_dict = {
                     "id": result.id,
                     "score": result.score,
                     "title": payload.get("title", "Untitled"),
-                    "content": payload.get("content", ""),
+                    "content": content_text,
                     "content_type": payload.get("content_type", "unknown"),
                     "mongo_id": payload.get("mongo_id"),
                 }


### PR DESCRIPTION
Fix empty content blocks in retrieval output by adding robust content fallbacks and adjust chunk coverage to be 1-based.

Previously, `CONTENT START/END` blocks in retrieval output could be empty if the `payload.content` field was missing from Qdrant points. This PR introduces fallbacks to use `payload.full_text` or `payload.title` if `payload.content` is unavailable, ensuring content is always displayed. It also updates chunk coverage indices to be 1-based for better readability.

---
<a href="https://cursor.com/background-agent?bcId=bc-a802759f-fb15-409f-8cb6-239bceb04d09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a802759f-fb15-409f-8cb6-239bceb04d09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

