### PR TITLE
Fix document retrieval chunking and scoring

### DIFF
--- a/qdrant/insertdocs.py
+++ b/qdrant/insertdocs.py
@@ -297,33 +297,33 @@ def point_id_from_seed(seed: str) -> str:
 
 # ------------------ Chunking Configuration ------------------
 
-# Chunking settings per content type
-# Adjust these values to control chunking behavior
+# Chunking settings per content type (more aggressive to ensure chunking happens)
+# Smaller chunks improve semantic matching and retrieval scores
 CHUNKING_CONFIG = {
     "page": {
-        "max_words": 320,
-        "overlap_words": 80,
-        "min_words_to_chunk": 320,  # Only chunk if text is longer than this
+        "max_words": 220,
+        "overlap_words": 60,
+        "min_words_to_chunk": 200,
     },
     "work_item": {
-        "max_words": 300,
-        "overlap_words": 60,
-        "min_words_to_chunk": 300,
+        "max_words": 180,
+        "overlap_words": 50,
+        "min_words_to_chunk": 160,
     },
     "project": {
-        "max_words": 300,
-        "overlap_words": 60,
-        "min_words_to_chunk": 300,
+        "max_words": 180,
+        "overlap_words": 50,
+        "min_words_to_chunk": 160,
     },
     "cycle": {
-        "max_words": 300,
-        "overlap_words": 60,
-        "min_words_to_chunk": 300,
+        "max_words": 180,
+        "overlap_words": 50,
+        "min_words_to_chunk": 160,
     },
     "module": {
-        "max_words": 300,
-        "overlap_words": 60,
-        "min_words_to_chunk": 300,
+        "max_words": 180,
+        "overlap_words": 50,
+        "min_words_to_chunk": 160,
     },
 }
 

--- a/tools.py
+++ b/tools.py
@@ -711,7 +711,7 @@ async def rag_search(
     query: str,
     content_type: str = None,
     group_by: str = None,
-    limit: int = 10,
+    limit: int = 5,
     show_content: bool = True,
     use_chunk_aware: bool = True
 ) -> str:
@@ -783,9 +783,9 @@ async def rag_search(
                 collection_name=QDRANT_COLLECTION_NAME,
                 content_type=content_type,
                 limit=limit,
-                chunks_per_doc=3,
+                chunks_per_doc=2,
                 include_adjacent=True,
-                min_score=0.5
+                min_score=0.6
             )
             
             if not reconstructed_docs:


### PR DESCRIPTION
Adjust Qdrant chunking configuration and retrieval parameters to improve similarity scores and reduce the number of retrieved documents.

The previous chunking configuration was too permissive, resulting in large or unchunked documents being indexed. This led to poor similarity matching and an excessive number of irrelevant documents being retrieved. The changes ensure more aggressive chunking and stricter retrieval criteria, prioritizing smaller, more relevant chunks.

---
<a href="https://cursor.com/background-agent?bcId=bc-2fbcd841-e166-4ae2-be57-4585aa6038f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2fbcd841-e166-4ae2-be57-4585aa6038f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

