### PR TITLE
Implement splade qdrant hybrid search

### DIFF
--- a/qdrant/splade_encoder.py
+++ b/qdrant/splade_encoder.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+"""
+Minimal SPLADE encoder utility.
+
+Provides a lightweight, cached interface to compute sparse vectors
+usable with Qdrant's sparse vectors API.
+
+Dependencies: transformers, torch
+Model: naver/splade-cocondenser-ensembledistil (masked LM head)
+"""
+
+from typing import Dict, List, Tuple
+import threading
+
+
+_encoder_singleton_lock = threading.Lock()
+_encoder_singleton: "SpladeEncoder | None" = None
+
+
+class SpladeEncoder:
+    """SPLADE encoder producing sparse (indices, values) vectors."""
+
+    def __init__(self, model_name: str = "naver/splade-cocondenser-ensembledistil") -> None:
+        # Lazy imports keep startup fast when SPLADE isn't used
+        from transformers import AutoTokenizer, AutoModelForMaskedLM  # type: ignore
+        import torch  # type: ignore
+
+        self.model_name = model_name
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+        self.model = AutoModelForMaskedLM.from_pretrained(model_name)
+        self.model.eval()
+        self.torch = torch
+
+    def encode_text(self, text: str, max_terms: int = 200) -> Dict[str, List[float]]:
+        """Encode text to SPLADE sparse representation.
+
+        Returns:
+            {"indices": List[int], "values": List[float]}
+        """
+        if not text or not text.strip():
+            return {"indices": [], "values": []}
+
+        torch = self.torch
+        # Tokenize and cap to model max length
+        inputs = self.tokenizer(
+            text,
+            return_tensors="pt",
+            truncation=True,
+            max_length=512,
+        )
+
+        with torch.no_grad():
+            logits = self.model(**inputs).logits.squeeze(0)  # [seq_len, vocab]
+            # SPLADE activation: log(1 + sum(ReLU(logits), dim=seq))
+            activated = torch.relu(logits)
+            aggregated = torch.log1p(torch.sum(activated, dim=0))  # [vocab]
+
+        # Select top-k terms to keep vector compact
+        k = min(max_terms, aggregated.numel())
+        values, indices = torch.topk(aggregated, k)
+
+        # Filter out zero or near-zero weights
+        mask = values > 0
+        values = values[mask]
+        indices = indices[mask]
+
+        # Convert to python lists
+        indices_list = [int(i) for i in indices.tolist()]
+        values_list = [float(v) for v in values.tolist()]
+
+        return {"indices": indices_list, "values": values_list}
+
+
+def get_splade_encoder() -> SpladeEncoder:
+    global _encoder_singleton
+    if _encoder_singleton is not None:
+        return _encoder_singleton
+    with _encoder_singleton_lock:
+        if _encoder_singleton is None:
+            _encoder_singleton = SpladeEncoder()
+        return _encoder_singleton

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,6 +35,10 @@ qdrant-client
 sentence-transformers
 numpy
 
+# SPLADE (sparse) dependencies
+transformers
+torch
+
 # Phoenix for LLM evaluation and tracing
 phoenix
 arize-phoenix


### PR DESCRIPTION
Implement SPLADE-based sparse vectors and hybrid search with Qdrant to improve retrieval relevance.

This PR integrates SPLADE sparse vector encoding and Qdrant's RRF fusion to combine dense and sparse search results, enhancing the relevance and recall of search queries. The Qdrant collection is reconfigured to support named vectors (`dense` and `sparse`), and all indexing paths now generate both vector types. Retrieval logic in `ChunkAwareRetriever` and `RAGTool` is updated to use this hybrid approach, with a fallback to keyword search if SPLADE is unavailable.

---
<a href="https://cursor.com/background-agent?bcId=bc-78147a88-8a81-483b-b4d9-32e412cbcbc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-78147a88-8a81-483b-b4d9-32e412cbcbc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

