### PR TITLE
Handle project query errors

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -105,7 +105,11 @@ class Orchestrator:
                             is_valid = bool(step.validator(result, context))
                         except Exception as ve:
                             is_valid = False
-                            span.add_event("validator_exception", {"message": str(ve)})
+                            try:
+                                if hasattr(span, "add_event"):
+                                    span.add_event("validator_exception", {"message": str(ve)})
+                            except Exception:
+                                pass
                         if not is_valid:
                             raise RuntimeError(f"Validation failed for step '{step.name}'")
 
@@ -116,9 +120,13 @@ class Orchestrator:
                         preview = str(result)[:400]
                     except Exception:
                         preview = "<unserializable>"
-                    span.set_attribute("step.success", True)
-                    span.set_attribute("step.duration_ms", duration_ms)
-                    span.set_attribute("output.preview", preview)
+                    try:
+                        if hasattr(span, "set_attribute"):
+                            span.set_attribute("step.success", True)
+                            span.set_attribute("step.duration_ms", duration_ms)
+                            span.set_attribute("output.preview", preview)
+                    except Exception:
+                        pass
                     return step.name, result, None
                 except Exception as e:  # noqa: BLE001
                     last_exc = e

--- a/planner.py
+++ b/planner.py
@@ -444,7 +444,7 @@ class LLMIntentParser:
             "## EXAMPLES\n"
             "- 'show me tasks assigned to alice' → {\"primary_entity\": \"workItem\", \"filters\": {\"assignee_name\": \"alice\"}, \"aggregations\": []}\n"
             "- 'how many bugs are there' → {\"primary_entity\": \"workItem\", \"aggregations\": [\"count\"]}\n"
-            "- 'count active projects' → {\"primary_entity\": \"project\", \"filters\": {\"project_status\": \"STARTED\"}, \"aggregations\": [\"count\"]}\n"
+            "- 'count active projects' → {\"primary_entity\": \"project\", \"filters\": {\"isActive\": true}, \"aggregations\": [\"count\"]}\n"
             "- 'group tasks by priority' → {\"primary_entity\": \"workItem\", \"aggregations\": [\"group\"], \"group_by\": [\"priority\"]}\n"
             "- 'show archived projects' → {\"primary_entity\": \"project\", \"filters\": {\"isArchived\": true}, \"aggregations\": []}\n"
             "- 'find favourite modules' → {\"primary_entity\": \"module\", \"filters\": {\"isFavourite\": true}, \"aggregations\": []}\n"
@@ -647,6 +647,13 @@ class LLMIntentParser:
             else:
                 # Keep other valid filters (including direct field filters and date range tokens)
                 filters[k] = v
+
+        # Heuristic: For project queries, interpret 'active projects' phrasing as isActive=true when not explicitly set
+        if primary == "project":
+            oq_lower = (original_query or "").lower()
+            mentions_active = "active" in oq_lower and not any(w in oq_lower for w in ["inactive", "archiv", "not active", "deactive"])
+            if mentions_active and "isActive" not in filters and "isArchived" not in filters and "project_status" not in filters:
+                filters["isActive"] = True
 
         
         # Heuristic enrichments from original query text (generalized)


### PR DESCRIPTION
Guard `span` attribute/event calls to prevent `NoneType` crash and update planner to correctly interpret "active projects" as `isActive: true`.

The `NoneType` object has no attribute `set_attribute` error occurred when the `span` object was `None` during tracing, leading to a crash. Additionally, the planner was not correctly interpreting "active projects" queries, resulting in no results. This PR fixes both issues by adding defensive checks and updating the intent parsing logic.

---
<a href="https://cursor.com/background-agent?bcId=bc-b8c1a66f-7b8a-4a5e-8e1f-d2d0afac5993"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b8c1a66f-7b8a-4a5e-8e1f-d2d0afac5993"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

